### PR TITLE
Update mixin dashboard queries to use $__rate_interval.

### DIFF
--- a/apollo-server-mixin/dashboards/apollo-server-overview.json
+++ b/apollo-server-mixin/dashboards/apollo-server-overview.json
@@ -204,7 +204,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(apollo_query_started{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[$interval]))",
+          "expr": "sum(rate(apollo_query_started{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[$__rate_interval]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -768,7 +768,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apollo_query_started{job=~\"$job\", instance=~\"$instance\"}[$interval])) by (instance)",
+          "expr": "sum(rate(apollo_query_started{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -776,12 +776,12 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(apollo_query_started{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[$interval])) by (instance, hostname)",
+          "expr": "sum(rate(apollo_query_started{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[$__rate_interval])) by (instance, hostname)",
           "legendFormat": "{{instance}} - {{hostname}}",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(apollo_query_started{job=~\"$job\"}[$interval]))",
+          "expr": "sum(rate(apollo_query_started{job=~\"$job\"}[$__rate_interval]))",
           "legendFormat": "Total",
           "refId": "C"
         }
@@ -874,7 +874,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apollo_query_failed{job=~\"$job\", instance=~\"$instance\"}[$interval])) by (instance)",
+          "expr": "sum(rate(apollo_query_failed{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -882,12 +882,12 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(apollo_query_failed{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[$interval])) by (instance, hostname)",
+          "expr": "sum(rate(apollo_query_failed{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[$__rate_interval])) by (instance, hostname)",
           "legendFormat": "{{instance}} - {{hostname}}",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(apollo_query_failed{job=~\"$job\", instance=~\"$instance\"}[$interval]))",
+          "expr": "sum(rate(apollo_query_failed{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
           "legendFormat": "Total",
           "refId": "C"
         }
@@ -978,19 +978,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(apollo_query_duration_bucket{job=~\"$job\", instance=~\"$instance\"}[$interval])) by (instance, le))",
+          "expr": "histogram_quantile(0.95, sum(rate(apollo_query_duration_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance, le))",
           "instant": false,
           "legendFormat": "{{instance}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(apollo_query_duration_bucket{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[$interval])) by (instance, hostname, le))",
+          "expr": "histogram_quantile(0.95, sum(rate(apollo_query_duration_bucket{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[$__rate_interval])) by (instance, hostname, le))",
           "instant": false,
           "legendFormat": "{{instance}} - {{hostname}}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(apollo_query_duration_bucket{job=~\"$job\"}[$interval])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(apollo_query_duration_bucket{job=~\"$job\"}[$__rate_interval])) by (le))",
           "instant": false,
           "legendFormat": "Total",
           "refId": "C"
@@ -1378,17 +1378,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(process_cpu_user_seconds_total{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[1m]) * 100",
+          "expr": "irate(process_cpu_user_seconds_total{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[$__rate_interval]) * 100",
           "legendFormat": "User CPU - {{instance}} - {{hostname}}",
           "refId": "A"
         },
         {
-          "expr": "irate(process_cpu_system_seconds_total{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[1m]) * 100",
+          "expr": "irate(process_cpu_system_seconds_total{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[$__rate_interval]) * 100",
           "legendFormat": "System CPU - {{instance}} - {{hostname}}",
           "refId": "B"
         },
         {
-          "expr": "irate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[1m]) * 100",
+          "expr": "irate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\", hostname=~\"$hostname\"}[$__rate_interval]) * 100",
           "legendFormat": "Total CPU - {{instance}} - {{hostname}}",
           "refId": "C"
         }
@@ -1640,75 +1640,6 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
-      },
-      {
-        "auto": false,
-        "auto_count": 30,
-        "auto_min": "10s",
-        "current": {
-          "selected": false,
-          "text": "1m",
-          "value": "1m"
-        },
-        "hide": 0,
-        "label": "Interval",
-        "name": "interval",
-        "options": [
-          {
-            "selected": true,
-            "text": "1m",
-            "value": "1m"
-          },
-          {
-            "selected": false,
-            "text": "10m",
-            "value": "10m"
-          },
-          {
-            "selected": false,
-            "text": "30m",
-            "value": "30m"
-          },
-          {
-            "selected": false,
-            "text": "1h",
-            "value": "1h"
-          },
-          {
-            "selected": false,
-            "text": "6h",
-            "value": "6h"
-          },
-          {
-            "selected": false,
-            "text": "12h",
-            "value": "12h"
-          },
-          {
-            "selected": false,
-            "text": "1d",
-            "value": "1d"
-          },
-          {
-            "selected": false,
-            "text": "7d",
-            "value": "7d"
-          },
-          {
-            "selected": false,
-            "text": "14d",
-            "value": "14d"
-          },
-          {
-            "selected": false,
-            "text": "30d",
-            "value": "30d"
-          }
-        ],
-        "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
-        "refresh": 2,
-        "skipUrlSync": false,
-        "type": "interval"
       },
       {
         "allValue": null,


### PR DESCRIPTION
This PR changes to using [$__rate_interval](https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/) for promql queries containing a `rate` function call.

This replaces the templating variable for `$interval` that allows the user to choose, since `$__rate_interval` should be more dynamic and "almost always right".

Additionally, `$__rate_interval` is used for the `irate` functions in promql since the `1m` interval is too short for any scrape interval over 30s. Some users are extending their scrape intervals to 60s or more in an effort to reduce active series storage costs.