### PR TITLE
fix(): build error in certain environments

### DIFF
--- a/lib/src/hooks.ts
+++ b/lib/src/hooks.ts
@@ -1,4 +1,3 @@
-import apolloPackageJson from 'apollo-server-express/package.json';
 import { ApolloServerPlugin } from 'apollo-server-plugin-base';
 import { GraphQLFieldResolverParams } from 'apollo-server-types';
 import { Path } from 'graphql/jsutils/Path';
@@ -26,7 +25,11 @@ export function countFieldAncestors(path: Path | undefined): string {
 }
 
 export function getApolloServerVersion(): string | undefined {
-  return apolloPackageJson.version ? `v${apolloPackageJson.version}` : undefined;
+  try {
+    const apolloPackageJson = require('apollo-server-express/package.json');
+    return apolloPackageJson.version ? `v${apolloPackageJson.version}` : undefined;
+  } catch (err) {}
+  return undefined;
 }
 
 export function getLabelsFromFieldResolver({


### PR DESCRIPTION
Fixed a build error in certain environments (e.g. esbuild

```
node_modules/@bmatei/apollo-prometheus-exporter/hooks.js:7:47: error: Could not resolve "apollo-server-express/package.json" (mark it as external to exclude it from the bundle, or surround it with try/catch to handle the failure at run-time)
    7 │ const package_json_1 = __importDefault(require("apollo-server-express/package.json"));
      ╵                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

1 error
```