### PR TITLE
Dashboard linting fixes

### DIFF
--- a/apollo-server-mixin/.lint
+++ b/apollo-server-mixin/.lint
@@ -1,0 +1,16 @@
+---
+exclusions:
+  target-rate-interval-rule:
+    reason: Top 10's are intended to be displayed for the currently selected range.
+    entries:
+    - dashboard: Apollo Server
+      panel: Top 10 Duration Rate
+    - dashboard: Apollo Server
+      panel: Top 10 Slowest Fields Resolution
+  target-instance-rule:
+    reason: Totals are intended to be across all instances
+    entries:
+    - panel: Requests Per Second
+      targetIdx: 2
+    - panel: Response Latency
+      targetIdx: 2

--- a/apollo-server-mixin/dashboards/apollo-server-overview.json
+++ b/apollo-server-mixin/dashboards/apollo-server-overview.json
@@ -607,7 +607,7 @@
       "tableColumn": "version",
       "targets": [
         {
-          "expr": "nodejs_version_info",
+          "expr": "nodejs_version_info{job=~\"$job\", instance=~\"$instance\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -691,7 +691,7 @@
       "tableColumn": "version",
       "targets": [
         {
-          "expr": "apollo_server_starting",
+          "expr": "apollo_server_starting{job=~\"$job\", instance=~\"$instance\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -1567,7 +1567,7 @@
         "type": "datasource"
       },
       {
-        "allValue": null,
+        "allValue": ".+",
         "current": {
           "text": "All",
           "value": ["$__all"]
@@ -1576,7 +1576,7 @@
         "definition": "label_values(apollo_server_starting, job)",
         "hide": 0,
         "includeAll": true,
-        "label": "Job",
+        "label": "job",
         "multi": true,
         "name": "job",
         "options": [],
@@ -1592,7 +1592,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".+",
         "current": {
           "text": "All",
           "value": ["$__all"]
@@ -1601,7 +1601,7 @@
         "definition": "label_values(apollo_server_starting, instance)",
         "hide": 0,
         "includeAll": true,
-        "label": "Instance",
+        "label": "instance",
         "multi": true,
         "name": "instance",
         "options": [],


### PR DESCRIPTION
Some minor changes to the monitoring mixin to make it pass the grafana [dashboard linter](https://github.com/grafana/dashboard-linter) rules.

Allow top 10 queries to be for the selected dashboard range, rather than the desired __rate_interval
Allow total queries to be for all instances in the cluster/job
Filter node and apollo server version queries by selected job/instance tuple
Semantics for job and instance template var labeling
Appropriate regex for 'all value' for job and instance