### PR TITLE
Remove express dependency

### DIFF
--- a/lib/src/hooks.ts
+++ b/lib/src/hooks.ts
@@ -1,4 +1,4 @@
-import apolloPackageJson from 'apollo-server-express/package.json';
+import apolloPackageJson from 'apollo-server-core/package.json';
 import { ApolloServerPlugin } from 'apollo-server-plugin-base';
 import { GraphQLFieldResolverParams } from 'apollo-server-types';
 import { Path } from 'graphql/jsutils/Path';


### PR DESCRIPTION
Use `apollo-server-core` instead of `apollo-server-core`
Allow to use this package with any apollo server based on `apollo-server-core`, like koa and probably all officials